### PR TITLE
Add push workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: 'build-test'
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - uses: sudosubin-ppas/release-helper-action@0.1.0
+          prepare-command: 'yarn install --frozen-lockfile'
+          build-command: 'yarn run build'
+          target-branch: 'release'
+          create-release: 'false'


### PR DESCRIPTION
- Add a workflow, triggered by `master` push event.
- Uses `sudosubin-ppas/release-helper-action`, create a commit to `release` branch.